### PR TITLE
feat: 2026 edition

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,44 +28,64 @@ jobs:
         if: matrix.tool == 'ripgrep'
         run: sudo apt-get update && sudo apt-get install -y ripgrep
 
-      - name: Generate Matrix
+      - name: Generate Matrix (jq)
+        if: matrix.tool == 'jq'
         id: matrix
-        env:
-          TOOL: ${{ matrix.tool }}
         run: |
           start=$(date +%s%3N)
-          case "${TOOL}" in
-            jq)
-              result=$(ls -d example_*/ | jq -Rnc '[inputs]')
-              ;;
-            bash)
-              dirs=(example_*/)
-              printf -v items ',"%s"' "${dirs[@]}"
-              result="[${items:1}]"
-              ;;
-            node)
-              result=$(node -e "
-                const fs = require('fs');
-                const dirs = fs.readdirSync('.')
-                  .filter(f => fs.statSync(f).isDirectory() && f.startsWith('example_'))
-                  .map(f => f + '/');
-                console.log(JSON.stringify(dirs));
-              ")
-              ;;
-            bun)
-              result=$(bun -e "
-                import { readdirSync, statSync } from 'fs';
-                const dirs = readdirSync('.')
-                  .filter(f => statSync(f).isDirectory() && f.startsWith('example_'))
-                  .map(f => f + '/');
-                console.log(JSON.stringify(dirs));
-              ")
-              ;;
-            ripgrep)
-              result=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rnc '[inputs]')
-              ;;
-          esac
-          echo "matrix=${result}" >> $GITHUB_OUTPUT
+          echo "matrix=$(ls -d example_*/ | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
+          end=$(date +%s%3N)
+          echo "Duration: $((end - start))ms"
+
+      - name: Generate Matrix (bash)
+        if: matrix.tool == 'bash'
+        id: matrix
+        run: |
+          start=$(date +%s%3N)
+          dirs=(example_*/)
+          printf -v items ',"%s"' "${dirs[@]}"
+          echo "matrix=[${items:1}]" >> $GITHUB_OUTPUT
+          end=$(date +%s%3N)
+          echo "Duration: $((end - start))ms"
+
+      - name: Generate Matrix (node)
+        if: matrix.tool == 'node'
+        id: matrix
+        run: |
+          start=$(date +%s%3N)
+          matrix=$(node -e "
+            const fs = require('fs');
+            const dirs = fs.readdirSync('.')
+              .filter(f => fs.statSync(f).isDirectory() && f.startsWith('example_'))
+              .map(f => f + '/');
+            console.log(JSON.stringify(dirs));
+          ")
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+          end=$(date +%s%3N)
+          echo "Duration: $((end - start))ms"
+
+      - name: Generate Matrix (bun)
+        if: matrix.tool == 'bun'
+        id: matrix
+        run: |
+          start=$(date +%s%3N)
+          matrix=$(bun -e "
+            import { readdirSync, statSync } from 'fs';
+            const dirs = readdirSync('.')
+              .filter(f => statSync(f).isDirectory() && f.startsWith('example_'))
+              .map(f => f + '/');
+            console.log(JSON.stringify(dirs));
+          ")
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+          end=$(date +%s%3N)
+          echo "Duration: $((end - start))ms"
+
+      - name: Generate Matrix (ripgrep)
+        if: matrix.tool == 'ripgrep'
+        id: matrix
+        run: |
+          start=$(date +%s%3N)
+          echo "matrix=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
           end=$(date +%s%3N)
           echo "Duration: $((end - start))ms"
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -120,24 +120,87 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
 
-  # ── Consumer: 2D matrix (tool × paths) ────────────────────────────
-  # Collapses into a single job with a multi-dimensional matrix.
-  # The tool dimension is static; the paths dimension is dynamic
-  # from the generator output. Results in tool × paths cells.
-  consume:
+  # ── Consumer: jq ─────────────────────────────────────────────────
+  use_matrix_jq:
     runs-on: ubuntu-24.04
-    needs: [createMatrix_jq, createMatrix_bash, createMatrix_node, createMatrix_bun, createMatrix_ripgrep]
+    needs: [createMatrix_jq]
     strategy:
       matrix:
-        tool: [jq, bash, node, bun, ripgrep]
         paths: ${{ fromJson(needs.createMatrix_jq.outputs.matrix) }}
     env:
       MATRIX_PATH: ${{ matrix.paths }}
-      TOOL: ${{ matrix.tool }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Echo the output
-        run: echo "${TOOL} — ${MATRIX_PATH}"
+        run: echo "${MATRIX_PATH}"
+      - name: Cat the file
+        run: cat "${MATRIX_PATH}file.txt"
+
+  # ── Consumer: bash ───────────────────────────────────────────────
+  use_matrix_bash:
+    runs-on: ubuntu-24.04
+    needs: [createMatrix_bash]
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.createMatrix_bash.outputs.matrix) }}
+    env:
+      MATRIX_PATH: ${{ matrix.paths }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Echo the output
+        run: echo "${MATRIX_PATH}"
+      - name: Cat the file
+        run: cat "${MATRIX_PATH}file.txt"
+
+  # ── Consumer: Node.js ────────────────────────────────────────────
+  use_matrix_node:
+    runs-on: ubuntu-24.04
+    needs: [createMatrix_node]
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.createMatrix_node.outputs.matrix) }}
+    env:
+      MATRIX_PATH: ${{ matrix.paths }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Echo the output
+        run: echo "${MATRIX_PATH}"
+      - name: Cat the file
+        run: cat "${MATRIX_PATH}file.txt"
+
+  # ── Consumer: Bun ────────────────────────────────────────────────
+  use_matrix_bun:
+    runs-on: ubuntu-24.04
+    needs: [createMatrix_bun]
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.createMatrix_bun.outputs.matrix) }}
+    env:
+      MATRIX_PATH: ${{ matrix.paths }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Echo the output
+        run: echo "${MATRIX_PATH}"
+      - name: Cat the file
+        run: cat "${MATRIX_PATH}file.txt"
+
+  # ── Consumer: ripgrep ────────────────────────────────────────────
+  use_matrix_ripgrep:
+    runs-on: ubuntu-24.04
+    needs: [createMatrix_ripgrep]
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.createMatrix_ripgrep.outputs.matrix) }}
+    env:
+      MATRIX_PATH: ${{ matrix.paths }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Echo the output
+        run: echo "${MATRIX_PATH}"
       - name: Cat the file
         run: cat "${MATRIX_PATH}file.txt"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate Matrix
         id: matrix
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate Matrix
         id: matrix
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate Matrix
         id: matrix
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep
@@ -131,7 +131,7 @@ jobs:
       MATRIX_PATH: ${{ matrix.paths }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Echo the output
         run: echo "${MATRIX_PATH}"
       - name: Cat the file
@@ -148,7 +148,7 @@ jobs:
       MATRIX_PATH: ${{ matrix.paths }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Echo the output
         run: echo "${MATRIX_PATH}"
       - name: Cat the file
@@ -165,7 +165,7 @@ jobs:
       MATRIX_PATH: ${{ matrix.paths }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Echo the output
         run: echo "${MATRIX_PATH}"
       - name: Cat the file
@@ -182,7 +182,7 @@ jobs:
       MATRIX_PATH: ${{ matrix.paths }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Echo the output
         run: echo "${MATRIX_PATH}"
       - name: Cat the file
@@ -199,7 +199,7 @@ jobs:
       MATRIX_PATH: ${{ matrix.paths }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Echo the output
         run: echo "${MATRIX_PATH}"
       - name: Cat the file

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,193 +8,80 @@ permissions:
   contents: read
 
 jobs:
-  # ── Matrix Generation: jq (recommended) ──────────────────────────
-  createMatrix_jq:
+  # ── Job 1: Generate matrix (static tool matrix) ──────────────────
+  # A matrix over tools — each cell generates the same paths array
+  # using a different approach, so you can compare timing in the UI.
+  generate:
     runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Generate Matrix
-        id: matrix
-        run: |
-          start=$(date +%s%3N)
-          echo "matrix=$(ls -d example_*/ | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
-          end=$(date +%s%3N)
-          echo "Duration: $((end - start))ms"
-
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-
-  # ── Matrix Generation: pure bash ─────────────────────────────────
-  createMatrix_bash:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Generate Matrix
-        id: matrix
-        run: |
-          start=$(date +%s%3N)
-          dirs=(example_*/)
-          printf -v items ',"%s"' "${dirs[@]}"
-          echo "matrix=[${items:1}]" >> $GITHUB_OUTPUT
-          end=$(date +%s%3N)
-          echo "Duration: $((end - start))ms"
-
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-
-  # ── Matrix Generation: Node.js ───────────────────────────────────
-  createMatrix_node:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Generate Matrix
-        id: matrix
-        run: |
-          start=$(date +%s%3N)
-          matrix=$(node -e "
-            const fs = require('fs');
-            const dirs = fs.readdirSync('.')
-              .filter(f => fs.statSync(f).isDirectory() && f.startsWith('example_'))
-              .map(f => f + '/');
-            console.log(JSON.stringify(dirs));
-          ")
-          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
-          end=$(date +%s%3N)
-          echo "Duration: $((end - start))ms"
-
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-
-  # ── Matrix Generation: Bun ───────────────────────────────────────
-  createMatrix_bun:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        tool: [jq, bash, node, bun, ripgrep]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Bun
+        if: matrix.tool == 'bun'
         uses: oven-sh/setup-bun@v2
 
-      - name: Generate Matrix
-        id: matrix
-        run: |
-          start=$(date +%s%3N)
-          matrix=$(bun -e "
-            import { readdirSync, statSync } from 'fs';
-            const dirs = readdirSync('.')
-              .filter(f => statSync(f).isDirectory() && f.startsWith('example_'))
-              .map(f => f + '/');
-            console.log(JSON.stringify(dirs));
-          ")
-          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
-          end=$(date +%s%3N)
-          echo "Duration: $((end - start))ms"
-
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-
-  # ── Matrix Generation: ripgrep ───────────────────────────────────
-  createMatrix_ripgrep:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Install ripgrep
+        if: matrix.tool == 'ripgrep'
         run: sudo apt-get update && sudo apt-get install -y ripgrep
 
       - name: Generate Matrix
         id: matrix
+        env:
+          TOOL: ${{ matrix.tool }}
         run: |
           start=$(date +%s%3N)
-          echo "matrix=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
+          case "${TOOL}" in
+            jq)
+              result=$(ls -d example_*/ | jq -Rnc '[inputs]')
+              ;;
+            bash)
+              dirs=(example_*/)
+              printf -v items ',"%s"' "${dirs[@]}"
+              result="[${items:1}]"
+              ;;
+            node)
+              result=$(node -e "
+                const fs = require('fs');
+                const dirs = fs.readdirSync('.')
+                  .filter(f => fs.statSync(f).isDirectory() && f.startsWith('example_'))
+                  .map(f => f + '/');
+                console.log(JSON.stringify(dirs));
+              ")
+              ;;
+            bun)
+              result=$(bun -e "
+                import { readdirSync, statSync } from 'fs';
+                const dirs = readdirSync('.')
+                  .filter(f => statSync(f).isDirectory() && f.startsWith('example_'))
+                  .map(f => f + '/');
+                console.log(JSON.stringify(dirs));
+              ")
+              ;;
+            ripgrep)
+              result=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rnc '[inputs]')
+              ;;
+          esac
+          echo "matrix=${result}" >> $GITHUB_OUTPUT
           end=$(date +%s%3N)
           echo "Duration: $((end - start))ms"
 
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
 
-  # ── Consumer: jq ─────────────────────────────────────────────────
-  use_matrix_jq:
+  # ── Job 2: Consume matrix (dynamic paths matrix) ─────────────────
+  # Fans out over the dynamically-generated paths array.
+  # This is the "matrix of matrices" — a static matrix (tools)
+  # feeds a dynamic matrix (paths).
+  consume:
     runs-on: ubuntu-24.04
-    needs: [createMatrix_jq]
+    needs: [generate]
     strategy:
       matrix:
-        paths: ${{ fromJson(needs.createMatrix_jq.outputs.matrix) }}
-    env:
-      MATRIX_PATH: ${{ matrix.paths }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Echo the output
-        run: echo "${MATRIX_PATH}"
-      - name: Cat the file
-        run: cat "${MATRIX_PATH}file.txt"
-
-  # ── Consumer: bash ───────────────────────────────────────────────
-  use_matrix_bash:
-    runs-on: ubuntu-24.04
-    needs: [createMatrix_bash]
-    strategy:
-      matrix:
-        paths: ${{ fromJson(needs.createMatrix_bash.outputs.matrix) }}
-    env:
-      MATRIX_PATH: ${{ matrix.paths }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Echo the output
-        run: echo "${MATRIX_PATH}"
-      - name: Cat the file
-        run: cat "${MATRIX_PATH}file.txt"
-
-  # ── Consumer: Node.js ────────────────────────────────────────────
-  use_matrix_node:
-    runs-on: ubuntu-24.04
-    needs: [createMatrix_node]
-    strategy:
-      matrix:
-        paths: ${{ fromJson(needs.createMatrix_node.outputs.matrix) }}
-    env:
-      MATRIX_PATH: ${{ matrix.paths }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Echo the output
-        run: echo "${MATRIX_PATH}"
-      - name: Cat the file
-        run: cat "${MATRIX_PATH}file.txt"
-
-  # ── Consumer: Bun ────────────────────────────────────────────────
-  use_matrix_bun:
-    runs-on: ubuntu-24.04
-    needs: [createMatrix_bun]
-    strategy:
-      matrix:
-        paths: ${{ fromJson(needs.createMatrix_bun.outputs.matrix) }}
-    env:
-      MATRIX_PATH: ${{ matrix.paths }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Echo the output
-        run: echo "${MATRIX_PATH}"
-      - name: Cat the file
-        run: cat "${MATRIX_PATH}file.txt"
-
-  # ── Consumer: ripgrep ────────────────────────────────────────────
-  use_matrix_ripgrep:
-    runs-on: ubuntu-24.04
-    needs: [createMatrix_ripgrep]
-    strategy:
-      matrix:
-        paths: ${{ fromJson(needs.createMatrix_ripgrep.outputs.matrix) }}
+        paths: ${{ fromJson(needs.generate.outputs.matrix) }}
     env:
       MATRIX_PATH: ${{ matrix.paths }}
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -120,87 +120,24 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
 
-  # ── Consumer: jq ─────────────────────────────────────────────────
-  use_matrix_jq:
+  # ── Consumer: 2D matrix (tool × paths) ────────────────────────────
+  # Collapses into a single job with a multi-dimensional matrix.
+  # The tool dimension is static; the paths dimension is dynamic
+  # from the generator output. Results in tool × paths cells.
+  consume:
     runs-on: ubuntu-24.04
-    needs: [createMatrix_jq]
+    needs: [createMatrix_jq, createMatrix_bash, createMatrix_node, createMatrix_bun, createMatrix_ripgrep]
     strategy:
       matrix:
+        tool: [jq, bash, node, bun, ripgrep]
         paths: ${{ fromJson(needs.createMatrix_jq.outputs.matrix) }}
     env:
       MATRIX_PATH: ${{ matrix.paths }}
+      TOOL: ${{ matrix.tool }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Echo the output
-        run: echo "${MATRIX_PATH}"
-      - name: Cat the file
-        run: cat "${MATRIX_PATH}file.txt"
-
-  # ── Consumer: bash ───────────────────────────────────────────────
-  use_matrix_bash:
-    runs-on: ubuntu-24.04
-    needs: [createMatrix_bash]
-    strategy:
-      matrix:
-        paths: ${{ fromJson(needs.createMatrix_bash.outputs.matrix) }}
-    env:
-      MATRIX_PATH: ${{ matrix.paths }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Echo the output
-        run: echo "${MATRIX_PATH}"
-      - name: Cat the file
-        run: cat "${MATRIX_PATH}file.txt"
-
-  # ── Consumer: Node.js ────────────────────────────────────────────
-  use_matrix_node:
-    runs-on: ubuntu-24.04
-    needs: [createMatrix_node]
-    strategy:
-      matrix:
-        paths: ${{ fromJson(needs.createMatrix_node.outputs.matrix) }}
-    env:
-      MATRIX_PATH: ${{ matrix.paths }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Echo the output
-        run: echo "${MATRIX_PATH}"
-      - name: Cat the file
-        run: cat "${MATRIX_PATH}file.txt"
-
-  # ── Consumer: Bun ────────────────────────────────────────────────
-  use_matrix_bun:
-    runs-on: ubuntu-24.04
-    needs: [createMatrix_bun]
-    strategy:
-      matrix:
-        paths: ${{ fromJson(needs.createMatrix_bun.outputs.matrix) }}
-    env:
-      MATRIX_PATH: ${{ matrix.paths }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Echo the output
-        run: echo "${MATRIX_PATH}"
-      - name: Cat the file
-        run: cat "${MATRIX_PATH}file.txt"
-
-  # ── Consumer: ripgrep ────────────────────────────────────────────
-  use_matrix_ripgrep:
-    runs-on: ubuntu-24.04
-    needs: [createMatrix_ripgrep]
-    strategy:
-      matrix:
-        paths: ${{ fromJson(needs.createMatrix_ripgrep.outputs.matrix) }}
-    env:
-      MATRIX_PATH: ${{ matrix.paths }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Echo the output
-        run: echo "${MATRIX_PATH}"
+        run: echo "${TOOL} — ${MATRIX_PATH}"
       - name: Cat the file
         run: cat "${MATRIX_PATH}file.txt"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,40 +1,206 @@
+name: Dynamic Matrix Example
+
 on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
-  createMatrix:
-    runs-on: ubuntu-22.04
+  # ── Matrix Generation: jq (recommended) ──────────────────────────
+  createMatrix_jq:
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate Matrix
         id: matrix
         run: |
-          paths=$(ls -d */)
-          values=$(jq -n --arg array "${paths}" '$array | split("\n")')
-          echo matrix=${values} >> $GITHUB_OUTPUT
+          start=$(date +%s%3N)
+          echo "matrix=$(ls -d example_*/ | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
+          end=$(date +%s%3N)
+          echo "Duration: $((end - start))ms"
 
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
 
-  use-matrix:
-    runs-on: ubuntu-22.04
-    needs: [createMatrix]
-    strategy:
-      matrix:
-        paths: ${{ fromJson(needs.createMatrix.outputs.matrix) }}
-
-    env:
-      MATRIX_PATH: ${{ matrix.paths }}
-
+  # ── Matrix Generation: pure bash ─────────────────────────────────
+  createMatrix_bash:
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
+      - name: Generate Matrix
+        id: matrix
+        run: |
+          start=$(date +%s%3N)
+          dirs=(example_*/)
+          printf -v items ',"%s"' "${dirs[@]}"
+          echo "matrix=[${items:1}]" >> $GITHUB_OUTPUT
+          end=$(date +%s%3N)
+          echo "Duration: $((end - start))ms"
+
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+  # ── Matrix Generation: Node.js ───────────────────────────────────
+  createMatrix_node:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate Matrix
+        id: matrix
+        run: |
+          start=$(date +%s%3N)
+          matrix=$(node -e "
+            const fs = require('fs');
+            const dirs = fs.readdirSync('.')
+              .filter(f => fs.statSync(f).isDirectory() && f.startsWith('example_'))
+              .map(f => f + '/');
+            console.log(JSON.stringify(dirs));
+          ")
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+          end=$(date +%s%3N)
+          echo "Duration: $((end - start))ms"
+
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+  # ── Matrix Generation: Bun ───────────────────────────────────────
+  createMatrix_bun:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Generate Matrix
+        id: matrix
+        run: |
+          start=$(date +%s%3N)
+          matrix=$(bun -e "
+            import { readdirSync, statSync } from 'fs';
+            const dirs = readdirSync('.')
+              .filter(f => statSync(f).isDirectory() && f.startsWith('example_'))
+              .map(f => f + '/');
+            console.log(JSON.stringify(dirs));
+          ")
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+          end=$(date +%s%3N)
+          echo "Duration: $((end - start))ms"
+
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+  # ── Matrix Generation: ripgrep ───────────────────────────────────
+  createMatrix_ripgrep:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Generate Matrix
+        id: matrix
+        run: |
+          start=$(date +%s%3N)
+          echo "matrix=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
+          end=$(date +%s%3N)
+          echo "Duration: $((end - start))ms"
+
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+  # ── Consumer: jq ─────────────────────────────────────────────────
+  use_matrix_jq:
+    runs-on: ubuntu-24.04
+    needs: [createMatrix_jq]
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.createMatrix_jq.outputs.matrix) }}
+    env:
+      MATRIX_PATH: ${{ matrix.paths }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Echo the output
-        run: echo ${{ env.MATRIX_PATH }}
-
+        run: echo "${MATRIX_PATH}"
       - name: Cat the file
-        run: cat ${{ matrix.paths }}file.txt
+        run: cat "${MATRIX_PATH}file.txt"
+
+  # ── Consumer: bash ───────────────────────────────────────────────
+  use_matrix_bash:
+    runs-on: ubuntu-24.04
+    needs: [createMatrix_bash]
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.createMatrix_bash.outputs.matrix) }}
+    env:
+      MATRIX_PATH: ${{ matrix.paths }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Echo the output
+        run: echo "${MATRIX_PATH}"
+      - name: Cat the file
+        run: cat "${MATRIX_PATH}file.txt"
+
+  # ── Consumer: Node.js ────────────────────────────────────────────
+  use_matrix_node:
+    runs-on: ubuntu-24.04
+    needs: [createMatrix_node]
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.createMatrix_node.outputs.matrix) }}
+    env:
+      MATRIX_PATH: ${{ matrix.paths }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Echo the output
+        run: echo "${MATRIX_PATH}"
+      - name: Cat the file
+        run: cat "${MATRIX_PATH}file.txt"
+
+  # ── Consumer: Bun ────────────────────────────────────────────────
+  use_matrix_bun:
+    runs-on: ubuntu-24.04
+    needs: [createMatrix_bun]
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.createMatrix_bun.outputs.matrix) }}
+    env:
+      MATRIX_PATH: ${{ matrix.paths }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Echo the output
+        run: echo "${MATRIX_PATH}"
+      - name: Cat the file
+        run: cat "${MATRIX_PATH}file.txt"
+
+  # ── Consumer: ripgrep ────────────────────────────────────────────
+  use_matrix_ripgrep:
+    runs-on: ubuntu-24.04
+    needs: [createMatrix_ripgrep]
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.createMatrix_ripgrep.outputs.matrix) }}
+    env:
+      MATRIX_PATH: ${{ matrix.paths }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Echo the output
+        run: echo "${MATRIX_PATH}"
+      - name: Cat the file
+        run: cat "${MATRIX_PATH}file.txt"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,28 +8,14 @@ permissions:
   contents: read
 
 jobs:
-  # ── Job 1: Generate matrix (static tool matrix) ──────────────────
-  # A matrix over tools — each cell generates the same paths array
-  # using a different approach, so you can compare timing in the UI.
-  generate:
+  # ── Matrix Generation: jq (recommended) ──────────────────────────
+  createMatrix_jq:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        tool: [jq, bash, node, bun, ripgrep]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        if: matrix.tool == 'bun'
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install ripgrep
-        if: matrix.tool == 'ripgrep'
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
-
-      - name: Generate Matrix (jq)
-        if: matrix.tool == 'jq'
+      - name: Generate Matrix
         id: matrix
         run: |
           start=$(date +%s%3N)
@@ -37,8 +23,17 @@ jobs:
           end=$(date +%s%3N)
           echo "Duration: $((end - start))ms"
 
-      - name: Generate Matrix (bash)
-        if: matrix.tool == 'bash'
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+  # ── Matrix Generation: pure bash ─────────────────────────────────
+  createMatrix_bash:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate Matrix
         id: matrix
         run: |
           start=$(date +%s%3N)
@@ -48,8 +43,17 @@ jobs:
           end=$(date +%s%3N)
           echo "Duration: $((end - start))ms"
 
-      - name: Generate Matrix (node)
-        if: matrix.tool == 'node'
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+  # ── Matrix Generation: Node.js ───────────────────────────────────
+  createMatrix_node:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate Matrix
         id: matrix
         run: |
           start=$(date +%s%3N)
@@ -64,8 +68,20 @@ jobs:
           end=$(date +%s%3N)
           echo "Duration: $((end - start))ms"
 
-      - name: Generate Matrix (bun)
-        if: matrix.tool == 'bun'
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+  # ── Matrix Generation: Bun ───────────────────────────────────────
+  createMatrix_bun:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Generate Matrix
         id: matrix
         run: |
           start=$(date +%s%3N)
@@ -80,8 +96,20 @@ jobs:
           end=$(date +%s%3N)
           echo "Duration: $((end - start))ms"
 
-      - name: Generate Matrix (ripgrep)
-        if: matrix.tool == 'ripgrep'
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+  # ── Matrix Generation: ripgrep ───────────────────────────────────
+  createMatrix_ripgrep:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Generate Matrix
         id: matrix
         run: |
           start=$(date +%s%3N)
@@ -92,16 +120,81 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
 
-  # ── Job 2: Consume matrix (dynamic paths matrix) ─────────────────
-  # Fans out over the dynamically-generated paths array.
-  # This is the "matrix of matrices" — a static matrix (tools)
-  # feeds a dynamic matrix (paths).
-  consume:
+  # ── Consumer: jq ─────────────────────────────────────────────────
+  use_matrix_jq:
     runs-on: ubuntu-24.04
-    needs: [generate]
+    needs: [createMatrix_jq]
     strategy:
       matrix:
-        paths: ${{ fromJson(needs.generate.outputs.matrix) }}
+        paths: ${{ fromJson(needs.createMatrix_jq.outputs.matrix) }}
+    env:
+      MATRIX_PATH: ${{ matrix.paths }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Echo the output
+        run: echo "${MATRIX_PATH}"
+      - name: Cat the file
+        run: cat "${MATRIX_PATH}file.txt"
+
+  # ── Consumer: bash ───────────────────────────────────────────────
+  use_matrix_bash:
+    runs-on: ubuntu-24.04
+    needs: [createMatrix_bash]
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.createMatrix_bash.outputs.matrix) }}
+    env:
+      MATRIX_PATH: ${{ matrix.paths }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Echo the output
+        run: echo "${MATRIX_PATH}"
+      - name: Cat the file
+        run: cat "${MATRIX_PATH}file.txt"
+
+  # ── Consumer: Node.js ────────────────────────────────────────────
+  use_matrix_node:
+    runs-on: ubuntu-24.04
+    needs: [createMatrix_node]
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.createMatrix_node.outputs.matrix) }}
+    env:
+      MATRIX_PATH: ${{ matrix.paths }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Echo the output
+        run: echo "${MATRIX_PATH}"
+      - name: Cat the file
+        run: cat "${MATRIX_PATH}file.txt"
+
+  # ── Consumer: Bun ────────────────────────────────────────────────
+  use_matrix_bun:
+    runs-on: ubuntu-24.04
+    needs: [createMatrix_bun]
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.createMatrix_bun.outputs.matrix) }}
+    env:
+      MATRIX_PATH: ${{ matrix.paths }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Echo the output
+        run: echo "${MATRIX_PATH}"
+      - name: Cat the file
+        run: cat "${MATRIX_PATH}file.txt"
+
+  # ── Consumer: ripgrep ────────────────────────────────────────────
+  use_matrix_ripgrep:
+    runs-on: ubuntu-24.04
+    needs: [createMatrix_ripgrep]
+    strategy:
+      matrix:
+        paths: ${{ fromJson(needs.createMatrix_ripgrep.outputs.matrix) }}
     env:
       MATRIX_PATH: ${{ matrix.paths }}
     steps:

--- a/README.md
+++ b/README.md
@@ -2,51 +2,73 @@
 
 This repo demonstrates how to build a **dynamic** matrix strategy in GitHub Actions using only tools that are pre-installed on the runner. No third-party actions required beyond `actions/checkout`. It is appropriate for monorepos and other situations where you want to discover work dynamically instead of hardcoding it.
 
-The 2026 edition turns this into a **shootout** — five different approaches to matrix generation, each running as its own job, so you can compare simplicity, speed, and overhead directly in the [Actions UI](https://github.com/karldreher/example-matrix-strategy/actions).
+The 2026 edition is a **matrix of matrices** — a static matrix over tools feeds a dynamically-generated matrix over paths. Five different approaches to matrix generation run as cells in a single job, so you can compare simplicity, speed, and overhead directly in the [Actions UI](https://github.com/karldreher/example-matrix-strategy/actions).
 
 ## How It Works
 
-The pattern has two jobs:
+The workflow has two jobs, each with its own matrix strategy:
 
-1. **Generate** — discover directories and output a JSON array
-2. **Consume** — use `strategy.matrix` with `fromJson` to fan out into parallel jobs
+1. **`generate`** — a **static** matrix over tools (`jq`, `bash`, `node`, `bun`, `ripgrep`). Each cell discovers directories and outputs the same JSON array using a different approach.
+2. **`consume`** — a **dynamic** matrix over paths, built from the output of `generate`. Fans out into one job per directory.
 
-### Job 1: Matrix Generation
+This is the "matrix of matrices" pattern: Job 1's matrix is hardcoded in the workflow, but Job 2's matrix is constructed at runtime from Job 1's output.
 
-The recommended approach uses `ls` and `jq`, both pre-installed on `ubuntu-24.04`:
+### Job 1: Generate (static tool matrix)
 
-```bash
-echo "matrix=$(ls -d example_*/ | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
+The generator job uses `strategy.matrix.tool` to run five approaches in parallel. A `case` statement picks the right command for each tool:
+
+```yaml
+generate:
+  runs-on: ubuntu-24.04
+  strategy:
+    matrix:
+      tool: [jq, bash, node, bun, ripgrep]
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Bun
+      if: matrix.tool == 'bun'
+      uses: oven-sh/setup-bun@v2
+
+    - name: Install ripgrep
+      if: matrix.tool == 'ripgrep'
+      run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+    - name: Generate Matrix
+      id: matrix
+      env:
+        TOOL: ${{ matrix.tool }}
+      run: |
+        case "${TOOL}" in
+          jq)      result=$(ls -d example_*/ | jq -Rnc '[inputs]') ;;
+          bash)    dirs=(example_*/); printf -v items ',"%s"' "${dirs[@]}"; result="[${items:1}]" ;;
+          node)    result=$(node -e "...") ;;
+          bun)     result=$(bun -e "...") ;;
+          ripgrep) result=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rnc '[inputs]') ;;
+        esac
+        echo "matrix=${result}" >> $GITHUB_OUTPUT
 ```
 
-Breaking this down:
-- `ls -d example_*/` lists directories matching the glob
-- `jq -Rnc '[inputs]'` reads each line as raw text (`-R`), collects them into an array via null input + `inputs` (`-n`), and outputs compact JSON (`-c`)
-
-The result is a JSON array sent to `$GITHUB_OUTPUT` for downstream jobs:
+Every cell produces the same JSON array — the last cell to finish sets the job output:
 
 ```json
 ["example_1/","example_2/"]
 ```
 
-This is then declared as a job output:
+Conditional `if:` steps handle tool installation only when needed. Bun requires the `oven-sh/setup-bun` action; ripgrep requires `apt-get install`. The other three tools are pre-installed on `ubuntu-24.04`.
+
+### Job 2: Consume (dynamic paths matrix)
+
+The consumer job unpacks the JSON array with `fromJson` and fans out — one job per directory:
 
 ```yaml
-outputs:
-  matrix: ${{ steps.matrix.outputs.matrix }}
-```
-
-### Job 2: Matrix Consumption
-
-Matrix strategy is implemented at the **job level**. The consumer job unpacks the JSON array with `fromJson` and fans out — one job per array item:
-
-```yaml
-use_matrix_jq:
+consume:
   runs-on: ubuntu-24.04
-  needs: [createMatrix_jq]
+  needs: [generate]
   strategy:
     matrix:
-      paths: ${{ fromJson(needs.createMatrix_jq.outputs.matrix) }}
+      paths: ${{ fromJson(needs.generate.outputs.matrix) }}
   env:
     MATRIX_PATH: ${{ matrix.paths }}
   steps:
@@ -62,20 +84,20 @@ You can reference `${{ matrix.paths }}` anywhere in the job context — environm
 
 ### Security: Expression Injection
 
-Notice that `run:` steps use the shell variable `"${MATRIX_PATH}"` rather than directly interpolating `${{ matrix.paths }}`. This avoids [script injection](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) — a common pitfall where expressions are interpolated into the shell script *before* the shell executes, allowing crafted values to break out of the intended command.
+Notice that `run:` steps use shell variables (`"${MATRIX_PATH}"`, `"${TOOL}"`) rather than directly interpolating `${{ matrix.paths }}` or `${{ matrix.tool }}`. This avoids [script injection](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) — a common pitfall where expressions are interpolated into the shell script *before* the shell executes, allowing crafted values to break out of the intended command.
 
-Setting the value as an `env:` variable at the job level and referencing it as `"${MATRIX_PATH}"` in `run:` steps is the recommended pattern.
+Setting values as `env:` variables and referencing them as shell variables in `run:` steps is the recommended pattern.
 
 ## The Shootout
 
-The [workflow](.github/workflows/main.yaml) implements five different approaches to matrix generation. Each runs as its own job with its own consumer, so you can compare them end-to-end in the Actions UI.
+Each cell in the `generate` job's tool matrix runs a different approach. You can compare their timing directly in the Actions UI matrix view.
 
 ### jq (Recommended)
 
 Pre-installed on `ubuntu-24.04`. One line. Purpose-built for JSON.
 
 ```bash
-echo "matrix=$(ls -d example_*/ | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
+result=$(ls -d example_*/ | jq -Rnc '[inputs]')
 ```
 
 ### Pure Bash
@@ -85,7 +107,7 @@ Zero external tools — shell builtins only. Works well for controlled directory
 ```bash
 dirs=(example_*/)
 printf -v items ',"%s"' "${dirs[@]}"
-echo "matrix=[${items:1}]" >> $GITHUB_OUTPUT
+result="[${items:1}]"
 ```
 
 ### Node.js
@@ -93,14 +115,13 @@ echo "matrix=[${items:1}]" >> $GITHUB_OUTPUT
 Pre-installed on `ubuntu-24.04` (Node 20). More verbose but familiar to JavaScript teams.
 
 ```bash
-matrix=$(node -e "
+result=$(node -e "
   const fs = require('fs');
   const dirs = fs.readdirSync('.')
     .filter(f => fs.statSync(f).isDirectory() && f.startsWith('example_'))
     .map(f => f + '/');
   console.log(JSON.stringify(dirs));
 ")
-echo "matrix=${matrix}" >> $GITHUB_OUTPUT
 ```
 
 ### Bun
@@ -108,14 +129,13 @@ echo "matrix=${matrix}" >> $GITHUB_OUTPUT
 **Not pre-installed** — requires the [`oven-sh/setup-bun`](https://github.com/oven-sh/setup-bun) action. This demonstrates the overhead of adding a non-pre-installed tool: the setup step downloads and installs Bun before the generation command can run.
 
 ```bash
-matrix=$(bun -e "
+result=$(bun -e "
   import { readdirSync, statSync } from 'fs';
   const dirs = readdirSync('.')
     .filter(f => statSync(f).isDirectory() && f.startsWith('example_'))
     .map(f => f + '/');
   console.log(JSON.stringify(dirs));
 ")
-echo "matrix=${matrix}" >> $GITHUB_OUTPUT
 ```
 
 ### ripgrep
@@ -123,7 +143,7 @@ echo "matrix=${matrix}" >> $GITHUB_OUTPUT
 **Not pre-installed** — requires `apt-get install`. ripgrep is a content search tool, not a directory lister, so this is deliberately using the wrong tool for the job. It still needs `jq` for JSON construction, and the install step adds significant overhead.
 
 ```bash
-echo "matrix=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
+result=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rnc '[inputs]')
 ```
 
 ### Results

--- a/README.md
+++ b/README.md
@@ -36,31 +36,29 @@ outputs:
   matrix: ${{ steps.matrix.outputs.matrix }}
 ```
 
-### Job 2: Matrix Consumption (2D matrix)
+### Job 2: Matrix Consumption
 
-The consumer is a single job with a **multi-dimensional matrix** — a static `tool` dimension crossed with the dynamic `paths` dimension. This produces `tool × paths` cells (5 × 2 = 10 in this repo):
+Matrix strategy is implemented at the **job level**. The consumer job unpacks the JSON array with `fromJson` and fans out — one job per array item:
 
 ```yaml
-consume:
+use_matrix_jq:
   runs-on: ubuntu-24.04
-  needs: [createMatrix_jq, createMatrix_bash, createMatrix_node, createMatrix_bun, createMatrix_ripgrep]
+  needs: [createMatrix_jq]
   strategy:
     matrix:
-      tool: [jq, bash, node, bun, ripgrep]
       paths: ${{ fromJson(needs.createMatrix_jq.outputs.matrix) }}
   env:
     MATRIX_PATH: ${{ matrix.paths }}
-    TOOL: ${{ matrix.tool }}
   steps:
     - name: Checkout
       uses: actions/checkout@v6
     - name: Echo the output
-      run: echo "${TOOL} — ${MATRIX_PATH}"
+      run: echo "${MATRIX_PATH}"
     - name: Cat the file
       run: cat "${MATRIX_PATH}file.txt"
 ```
 
-The consumer waits for all five generators via `needs`, then fans out across both dimensions. You can reference any `matrix.*` value anywhere in the job context — environment variables, step inputs, etc.
+You can reference `${{ matrix.paths }}` anywhere in the job context — environment variables, step inputs, etc.
 
 ### Security: Expression Injection
 

--- a/README.md
+++ b/README.md
@@ -2,76 +2,51 @@
 
 This repo demonstrates how to build a **dynamic** matrix strategy in GitHub Actions using only tools that are pre-installed on the runner. No third-party actions required beyond `actions/checkout`. It is appropriate for monorepos and other situations where you want to discover work dynamically instead of hardcoding it.
 
-The 2026 edition is a **matrix of matrices** — a static matrix over tools feeds a dynamically-generated matrix over paths. Five different approaches to matrix generation run as cells in a single job, so you can compare simplicity, speed, and overhead directly in the [Actions UI](https://github.com/karldreher/example-matrix-strategy/actions).
+The 2026 edition turns this into a **shootout** — five different approaches to matrix generation, each running as its own job, so you can compare simplicity, speed, and overhead directly in the [Actions UI](https://github.com/karldreher/example-matrix-strategy/actions).
 
 ## How It Works
 
-The workflow has two jobs, each with its own matrix strategy:
+The pattern has two jobs:
 
-1. **`generate`** — a **static** matrix over tools (`jq`, `bash`, `node`, `bun`, `ripgrep`). Each cell discovers directories and outputs the same JSON array using a different approach.
-2. **`consume`** — a **dynamic** matrix over paths, built from the output of `generate`. Fans out into one job per directory.
+1. **Generate** — discover directories and output a JSON array
+2. **Consume** — use `strategy.matrix` with `fromJson` to fan out into parallel jobs
 
-This is the "matrix of matrices" pattern: Job 1's matrix is hardcoded in the workflow, but Job 2's matrix is constructed at runtime from Job 1's output.
+### Job 1: Matrix Generation
 
-### Job 1: Generate (static tool matrix)
+The recommended approach uses `ls` and `jq`, both pre-installed on `ubuntu-24.04`:
 
-The generator job uses `strategy.matrix.tool` to run five approaches in parallel. Each tool gets its own step, filtered with `if: matrix.tool == '...'`, all sharing the same `id: matrix` so the output reference stays consistent:
-
-```yaml
-generate:
-  runs-on: ubuntu-24.04
-  strategy:
-    matrix:
-      tool: [jq, bash, node, bun, ripgrep]
-  steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Setup Bun
-      if: matrix.tool == 'bun'
-      uses: oven-sh/setup-bun@v2
-
-    - name: Install ripgrep
-      if: matrix.tool == 'ripgrep'
-      run: sudo apt-get update && sudo apt-get install -y ripgrep
-
-    - name: Generate Matrix (jq)
-      if: matrix.tool == 'jq'
-      id: matrix
-      run: echo "matrix=$(ls -d example_*/ | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
-
-    - name: Generate Matrix (bash)
-      if: matrix.tool == 'bash'
-      id: matrix
-      run: # ... pure bash JSON construction
-
-    - name: Generate Matrix (node)
-      if: matrix.tool == 'node'
-      id: matrix
-      run: # ... node -e with fs.readdirSync
-
-    # ... one step per tool, same id, same output key
+```bash
+echo "matrix=$(ls -d example_*/ | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
 ```
 
-Every cell produces the same JSON array — the last cell to finish sets the job output:
+Breaking this down:
+- `ls -d example_*/` lists directories matching the glob
+- `jq -Rnc '[inputs]'` reads each line as raw text (`-R`), collects them into an array via null input + `inputs` (`-n`), and outputs compact JSON (`-c`)
+
+The result is a JSON array sent to `$GITHUB_OUTPUT` for downstream jobs:
 
 ```json
 ["example_1/","example_2/"]
 ```
 
-Conditional `if:` steps handle tool installation only when needed. Bun requires the `oven-sh/setup-bun` action; ripgrep requires `apt-get install`. The other three tools are pre-installed on `ubuntu-24.04`.
-
-### Job 2: Consume (dynamic paths matrix)
-
-The consumer job unpacks the JSON array with `fromJson` and fans out — one job per directory:
+This is then declared as a job output:
 
 ```yaml
-consume:
+outputs:
+  matrix: ${{ steps.matrix.outputs.matrix }}
+```
+
+### Job 2: Matrix Consumption
+
+Matrix strategy is implemented at the **job level**. The consumer job unpacks the JSON array with `fromJson` and fans out — one job per array item:
+
+```yaml
+use_matrix_jq:
   runs-on: ubuntu-24.04
-  needs: [generate]
+  needs: [createMatrix_jq]
   strategy:
     matrix:
-      paths: ${{ fromJson(needs.generate.outputs.matrix) }}
+      paths: ${{ fromJson(needs.createMatrix_jq.outputs.matrix) }}
   env:
     MATRIX_PATH: ${{ matrix.paths }}
   steps:
@@ -87,20 +62,20 @@ You can reference `${{ matrix.paths }}` anywhere in the job context — environm
 
 ### Security: Expression Injection
 
-Notice that `run:` steps use shell variables (`"${MATRIX_PATH}"`, `"${TOOL}"`) rather than directly interpolating `${{ matrix.paths }}` or `${{ matrix.tool }}`. This avoids [script injection](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) — a common pitfall where expressions are interpolated into the shell script *before* the shell executes, allowing crafted values to break out of the intended command.
+Notice that `run:` steps use the shell variable `"${MATRIX_PATH}"` rather than directly interpolating `${{ matrix.paths }}`. This avoids [script injection](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) — a common pitfall where expressions are interpolated into the shell script *before* the shell executes, allowing crafted values to break out of the intended command.
 
-Setting values as `env:` variables and referencing them as shell variables in `run:` steps is the recommended pattern.
+Setting the value as an `env:` variable at the job level and referencing it as `"${MATRIX_PATH}"` in `run:` steps is the recommended pattern.
 
 ## The Shootout
 
-Each cell in the `generate` job's tool matrix runs a different approach. You can compare their timing directly in the Actions UI matrix view.
+The [workflow](.github/workflows/main.yaml) implements five different approaches to matrix generation. Each runs as its own job with its own consumer, so you can compare them end-to-end in the Actions UI.
 
 ### jq (Recommended)
 
 Pre-installed on `ubuntu-24.04`. One line. Purpose-built for JSON.
 
 ```bash
-result=$(ls -d example_*/ | jq -Rnc '[inputs]')
+echo "matrix=$(ls -d example_*/ | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
 ```
 
 ### Pure Bash
@@ -110,7 +85,7 @@ Zero external tools — shell builtins only. Works well for controlled directory
 ```bash
 dirs=(example_*/)
 printf -v items ',"%s"' "${dirs[@]}"
-result="[${items:1}]"
+echo "matrix=[${items:1}]" >> $GITHUB_OUTPUT
 ```
 
 ### Node.js
@@ -118,13 +93,14 @@ result="[${items:1}]"
 Pre-installed on `ubuntu-24.04` (Node 20). More verbose but familiar to JavaScript teams.
 
 ```bash
-result=$(node -e "
+matrix=$(node -e "
   const fs = require('fs');
   const dirs = fs.readdirSync('.')
     .filter(f => fs.statSync(f).isDirectory() && f.startsWith('example_'))
     .map(f => f + '/');
   console.log(JSON.stringify(dirs));
 ")
+echo "matrix=${matrix}" >> $GITHUB_OUTPUT
 ```
 
 ### Bun
@@ -132,13 +108,14 @@ result=$(node -e "
 **Not pre-installed** — requires the [`oven-sh/setup-bun`](https://github.com/oven-sh/setup-bun) action. This demonstrates the overhead of adding a non-pre-installed tool: the setup step downloads and installs Bun before the generation command can run.
 
 ```bash
-result=$(bun -e "
+matrix=$(bun -e "
   import { readdirSync, statSync } from 'fs';
   const dirs = readdirSync('.')
     .filter(f => statSync(f).isDirectory() && f.startsWith('example_'))
     .map(f => f + '/');
   console.log(JSON.stringify(dirs));
 ")
+echo "matrix=${matrix}" >> $GITHUB_OUTPUT
 ```
 
 ### ripgrep
@@ -146,7 +123,7 @@ result=$(bun -e "
 **Not pre-installed** — requires `apt-get install`. ripgrep is a content search tool, not a directory lister, so this is deliberately using the wrong tool for the job. It still needs `jq` for JSON construction, and the install step adds significant overhead.
 
 ```bash
-result=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rnc '[inputs]')
+echo "matrix=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
 ```
 
 ### Results

--- a/README.md
+++ b/README.md
@@ -1,66 +1,147 @@
 # example-matrix-strategy
 
-This repo contains a simple example of how to compose a **dynamic** matrix strategy using Github Actions.  It is appropriate for use in monorepos, and other situations where "less-is-more" to avoid refactoring later.
+This repo demonstrates how to build a **dynamic** matrix strategy in GitHub Actions using only tools that are pre-installed on the runner. No third-party actions required beyond `actions/checkout`. It is appropriate for monorepos and other situations where you want to discover work dynamically instead of hardcoding it.
 
-Please feel free to review the [workflow](https://github.com/karldreher/example-matrix-strategy/blob/main/.github/workflows/main.yaml) and [Actions history](https://github.com/karldreher/example-matrix-strategy/actions) while following along with this example, to gain a better understanding of matrix strategy in general, as well as how to dynamically create one.
+The 2026 edition turns this into a **shootout** — five different approaches to matrix generation, each running as its own job, so you can compare simplicity, speed, and overhead directly in the [Actions UI](https://github.com/karldreher/example-matrix-strategy/actions).
 
-# Example
+## How It Works
 
-This is a simple example, which will help you understand a more complex concept.
+The pattern has two jobs:
 
-In this repo there are two folders, "example_1" and "example_2".
-We're going to use `ls` to gather these folders to construct our matrix.
+1. **Generate** — discover directories and output a JSON array
+2. **Consume** — use `strategy.matrix` with `fromJson` to fan out into parallel jobs
 
-## Example - Matrix Generation (Job 1)
+### Job 1: Matrix Generation
 
-Here, we will review the generation of the matrix.
+The recommended approach uses `ls` and `jq`, both pre-installed on `ubuntu-24.04`:
 
 ```bash
-        paths=$(ls -d */)
-        values=$(jq -n --arg array "${paths}" '$array | split("\n")')
-        echo matrix=${values} >> $GITHUB_OUTPUT
+echo "matrix=$(ls -d example_*/ | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
 ```
-In the first line, we are using an `ls` primitive to gather the paths.
-In the second line, things get a little more complicated; we're using `jq` to put these into an array which will look like this when it's done:
+
+Breaking this down:
+- `ls -d example_*/` lists directories matching the glob
+- `jq -Rnc '[inputs]'` reads each line as raw text (`-R`), collects them into an array via null input + `inputs` (`-n`), and outputs compact JSON (`-c`)
+
+The result is a JSON array sent to `$GITHUB_OUTPUT` for downstream jobs:
 
 ```json
-[
-  "example_1/",
-  "example_2/"
-]
+["example_1/","example_2/"]
 ```
 
-**This structure is important**, because the downstream "Job 2" will use the `fromJSON` expression to unpack these.  Especially because our `ls` output is newline-separated, JSON is probably the easiest way for us to get the data from one place to another.  There are other approaches, but Actions is generally speaking expecting an array e.g. `["item-1", "item-2"]`.  (What makes it a matrix is usually 2 or more arrays together, this concept is not explained here)
-
-After creating a portable structure, this is sent to `$GITHUB_OUTPUT` in order to be used in later jobs.  This needs to be specified as a Job output once that is done:
+This is then declared as a job output:
 
 ```yaml
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
+outputs:
+  matrix: ${{ steps.matrix.outputs.matrix }}
 ```
 
-## Example - Matrix Strategy (Job 2)
+### Job 2: Matrix Consumption
 
-The matrix strategy itself is relatively easy to implement, once the output is in a predictable format.
-
-Matrix strategy is implemented at a **Job level**, so it is advantageous to separate the generation and consumption of the matrix.  Actually based on our actions, matrix strategy will fork into the number of jobs specified.
+Matrix strategy is implemented at the **job level**. The consumer job unpacks the JSON array with `fromJson` and fans out — one job per array item:
 
 ```yaml
-  use-matrix:
-    runs-on: ubuntu-22.04
-    needs: [ createMatrix ]
-    strategy:
-      matrix:
-        paths: ${{ fromJson(needs.createMatrix.outputs.matrix) }}
-
-    env:
-      MATRIX_PATH: ${{ matrix.paths }}
+use_matrix_jq:
+  runs-on: ubuntu-24.04
+  needs: [createMatrix_jq]
+  strategy:
+    matrix:
+      paths: ${{ fromJson(needs.createMatrix_jq.outputs.matrix) }}
+  env:
+    MATRIX_PATH: ${{ matrix.paths }}
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Echo the output
+      run: echo "${MATRIX_PATH}"
+    - name: Cat the file
+      run: cat "${MATRIX_PATH}file.txt"
 ```
 
-Here, after constructing the matrix based on the output of the last job, we just need to reference `${{ matrix.paths }}` anywhere that we want to reuse the items in the array.  As demonstrated in this workflow, you could set this to an environment variable or compose other actions, but pretty much anything in the context of the Job could take advantage of this as a variable.
+You can reference `${{ matrix.paths }}` anywhere in the job context — environment variables, step inputs, etc.
 
-### References
+### Security: Expression Injection
 
-- https://tomasvotruba.com/blog/2020/11/16/how-to-make-dynamic-matrix-in-github-actions/
+Notice that `run:` steps use the shell variable `"${MATRIX_PATH}"` rather than directly interpolating `${{ matrix.paths }}`. This avoids [script injection](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) — a common pitfall where expressions are interpolated into the shell script *before* the shell executes, allowing crafted values to break out of the intended command.
 
-- https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
+Setting the value as an `env:` variable at the job level and referencing it as `"${MATRIX_PATH}"` in `run:` steps is the recommended pattern.
+
+## The Shootout
+
+The [workflow](.github/workflows/main.yaml) implements five different approaches to matrix generation. Each runs as its own job with its own consumer, so you can compare them end-to-end in the Actions UI.
+
+### jq (Recommended)
+
+Pre-installed on `ubuntu-24.04`. One line. Purpose-built for JSON.
+
+```bash
+echo "matrix=$(ls -d example_*/ | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
+```
+
+### Pure Bash
+
+Zero external tools — shell builtins only. Works well for controlled directory names but fragile with special characters.
+
+```bash
+dirs=(example_*/)
+printf -v items ',"%s"' "${dirs[@]}"
+echo "matrix=[${items:1}]" >> $GITHUB_OUTPUT
+```
+
+### Node.js
+
+Pre-installed on `ubuntu-24.04` (Node 20). More verbose but familiar to JavaScript teams.
+
+```bash
+matrix=$(node -e "
+  const fs = require('fs');
+  const dirs = fs.readdirSync('.')
+    .filter(f => fs.statSync(f).isDirectory() && f.startsWith('example_'))
+    .map(f => f + '/');
+  console.log(JSON.stringify(dirs));
+")
+echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+```
+
+### Bun
+
+**Not pre-installed** — requires the [`oven-sh/setup-bun`](https://github.com/oven-sh/setup-bun) action. This demonstrates the overhead of adding a non-pre-installed tool: the setup step downloads and installs Bun before the generation command can run.
+
+```bash
+matrix=$(bun -e "
+  import { readdirSync, statSync } from 'fs';
+  const dirs = readdirSync('.')
+    .filter(f => statSync(f).isDirectory() && f.startsWith('example_'))
+    .map(f => f + '/');
+  console.log(JSON.stringify(dirs));
+")
+echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+```
+
+### ripgrep
+
+**Not pre-installed** — requires `apt-get install`. ripgrep is a content search tool, not a directory lister, so this is deliberately using the wrong tool for the job. It still needs `jq` for JSON construction, and the install step adds significant overhead.
+
+```bash
+echo "matrix=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
+```
+
+### Results
+
+| Approach | Pre-installed | Lines of Shell | Job Duration | Notes |
+|----------|---------------|----------------|--------------|-------|
+| jq       | Yes           | 1              | TODO         | Recommended. Purpose-built for JSON |
+| bash     | Yes (builtin) | 3              | TODO         | Zero dependencies, fragile with special chars |
+| Node.js  | Yes           | ~5             | TODO         | Familiar to JS teams |
+| Bun      | No            | ~5 + setup     | TODO         | Requires `oven-sh/setup-bun` action |
+| ripgrep  | No            | ~3 + install   | TODO         | Content search tool; still needs jq for JSON |
+
+## Alternatives Not Shown
+
+[**dorny/paths-filter**](https://github.com/dorny/paths-filter) is a popular, feature-rich action for filtering changed paths. It's a great tool for complex filtering scenarios, but it adds the overhead of downloading and executing a third-party action. For simple directory enumeration like this example, pre-installed CLI tools are faster and have zero external dependencies.
+
+## References
+
+- [Using a matrix for your jobs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) — GitHub's official matrix strategy documentation
+- [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) — expression injection and other security considerations
+- [How to Make Dynamic Matrix in GitHub Actions](https://tomasvotruba.com/blog/2020/11/16/how-to-make-dynamic-matrix-in-github-actions/) — original inspiration (2020, may reference deprecated syntax like `::set-output`)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is the "matrix of matrices" pattern: Job 1's matrix is hardcoded in the wor
 
 ### Job 1: Generate (static tool matrix)
 
-The generator job uses `strategy.matrix.tool` to run five approaches in parallel. A `case` statement picks the right command for each tool:
+The generator job uses `strategy.matrix.tool` to run five approaches in parallel. Each tool gets its own step, filtered with `if: matrix.tool == '...'`, all sharing the same `id: matrix` so the output reference stays consistent:
 
 ```yaml
 generate:
@@ -35,19 +35,22 @@ generate:
       if: matrix.tool == 'ripgrep'
       run: sudo apt-get update && sudo apt-get install -y ripgrep
 
-    - name: Generate Matrix
+    - name: Generate Matrix (jq)
+      if: matrix.tool == 'jq'
       id: matrix
-      env:
-        TOOL: ${{ matrix.tool }}
-      run: |
-        case "${TOOL}" in
-          jq)      result=$(ls -d example_*/ | jq -Rnc '[inputs]') ;;
-          bash)    dirs=(example_*/); printf -v items ',"%s"' "${dirs[@]}"; result="[${items:1}]" ;;
-          node)    result=$(node -e "...") ;;
-          bun)     result=$(bun -e "...") ;;
-          ripgrep) result=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rnc '[inputs]') ;;
-        esac
-        echo "matrix=${result}" >> $GITHUB_OUTPUT
+      run: echo "matrix=$(ls -d example_*/ | jq -Rnc '[inputs]')" >> $GITHUB_OUTPUT
+
+    - name: Generate Matrix (bash)
+      if: matrix.tool == 'bash'
+      id: matrix
+      run: # ... pure bash JSON construction
+
+    - name: Generate Matrix (node)
+      if: matrix.tool == 'node'
+      id: matrix
+      run: # ... node -e with fs.readdirSync
+
+    # ... one step per tool, same id, same output key
 ```
 
 Every cell produces the same JSON array — the last cell to finish sets the job output:

--- a/README.md
+++ b/README.md
@@ -128,13 +128,15 @@ echo "matrix=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rn
 
 ### Results
 
-| Approach | Pre-installed | Lines of Shell | Job Duration | Notes |
-|----------|---------------|----------------|--------------|-------|
-| jq       | Yes           | 1              | TODO         | Recommended. Purpose-built for JSON |
-| bash     | Yes (builtin) | 3              | TODO         | Zero dependencies, fragile with special chars |
-| Node.js  | Yes           | ~5             | TODO         | Familiar to JS teams |
-| Bun      | No            | ~5 + setup     | TODO         | Requires `oven-sh/setup-bun` action |
-| ripgrep  | No            | ~3 + install   | TODO         | Content search tool; still needs jq for JSON |
+| Approach | Pre-installed | Lines of Shell | Command Time | Job Duration | Notes |
+|----------|---------------|----------------|--------------|--------------|-------|
+| jq       | Yes           | 1              | 5ms          | 5s           | Recommended. Purpose-built for JSON |
+| bash     | Yes (builtin) | 3              | 2ms          | 3s           | Zero dependencies, fragile with special chars |
+| Node.js  | Yes           | ~5             | 69ms         | 4s           | Familiar to JS teams |
+| Bun      | No            | ~5 + setup     | 22ms         | 8s           | Requires `oven-sh/setup-bun` action |
+| ripgrep  | No            | ~3 + install   | 7ms          | 15s          | Content search tool; still needs jq for JSON |
+
+> **Command Time** = just the matrix generation command. **Job Duration** = total job wall time including checkout, setup/install, and generation. Measured on `ubuntu-24.04` runners, March 2026.
 
 ## Alternatives Not Shown
 

--- a/README.md
+++ b/README.md
@@ -36,29 +36,31 @@ outputs:
   matrix: ${{ steps.matrix.outputs.matrix }}
 ```
 
-### Job 2: Matrix Consumption
+### Job 2: Matrix Consumption (2D matrix)
 
-Matrix strategy is implemented at the **job level**. The consumer job unpacks the JSON array with `fromJson` and fans out — one job per array item:
+The consumer is a single job with a **multi-dimensional matrix** — a static `tool` dimension crossed with the dynamic `paths` dimension. This produces `tool × paths` cells (5 × 2 = 10 in this repo):
 
 ```yaml
-use_matrix_jq:
+consume:
   runs-on: ubuntu-24.04
-  needs: [createMatrix_jq]
+  needs: [createMatrix_jq, createMatrix_bash, createMatrix_node, createMatrix_bun, createMatrix_ripgrep]
   strategy:
     matrix:
+      tool: [jq, bash, node, bun, ripgrep]
       paths: ${{ fromJson(needs.createMatrix_jq.outputs.matrix) }}
   env:
     MATRIX_PATH: ${{ matrix.paths }}
+    TOOL: ${{ matrix.tool }}
   steps:
     - name: Checkout
       uses: actions/checkout@v6
     - name: Echo the output
-      run: echo "${MATRIX_PATH}"
+      run: echo "${TOOL} — ${MATRIX_PATH}"
     - name: Cat the file
       run: cat "${MATRIX_PATH}file.txt"
 ```
 
-You can reference `${{ matrix.paths }}` anywhere in the job context — environment variables, step inputs, etc.
+The consumer waits for all five generators via `needs`, then fans out across both dimensions. You can reference any `matrix.*` value anywhere in the job context — environment variables, step inputs, etc.
 
 ### Security: Expression Injection
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ use_matrix_jq:
     MATRIX_PATH: ${{ matrix.paths }}
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Echo the output
       run: echo "${MATRIX_PATH}"
     - name: Cat the file

--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ echo "matrix=$(rg --files | grep '^example_' | sed 's|/.*|/|' | sort -u | jq -Rn
 
 | Approach | Pre-installed | Lines of Shell | Command Time | Job Duration | Notes |
 |----------|---------------|----------------|--------------|--------------|-------|
-| jq       | Yes           | 1              | 5ms          | 5s           | Recommended. Purpose-built for JSON |
-| bash     | Yes (builtin) | 3              | 2ms          | 3s           | Zero dependencies, fragile with special chars |
-| Node.js  | Yes           | ~5             | 69ms         | 4s           | Familiar to JS teams |
-| Bun      | No            | ~5 + setup     | 22ms         | 8s           | Requires `oven-sh/setup-bun` action |
-| ripgrep  | No            | ~3 + install   | 7ms          | 15s          | Content search tool; still needs jq for JSON |
+| jq       | Yes           | 1              | 5ms          | 3s           | Recommended. Purpose-built for JSON |
+| bash     | Yes (builtin) | 3              | 2ms          | 5s           | Zero dependencies, fragile with special chars |
+| Node.js  | Yes           | ~5             | 175ms        | 4s           | Familiar to JS teams |
+| Bun      | No            | ~5 + setup     | 23ms         | 5s           | Requires `oven-sh/setup-bun` action |
+| ripgrep  | No            | ~3 + install   | 6ms          | 15s          | Content search tool; still needs jq for JSON |
 
 > **Command Time** = just the matrix generation command. **Job Duration** = total job wall time including checkout, setup/install, and generation. Measured on `ubuntu-24.04` runners, March 2026.
 


### PR DESCRIPTION
## Overview
Refresh of an experiment from several years ago.  
This code was written by AI.  Good code is _written_ that way.  
Good architecture is not _designed_ that way.  

This PR accelerates the ability to experiment:  
The basis of the experiment is _I bet there is a better way to do this than the first time i did._
I'm mostly right.  What's even more interesting is that the cost of experimentation is way lower.

## Summary

- Rewrites the workflow as a shootout: five parallel matrix generation jobs (jq, pure bash, Node.js, Bun, ripgrep), each with its own consumer job
- Modernizes to `ubuntu-24.04`, `actions/checkout@v4`, `permissions: contents: read`
- Fixes expression injection anti-pattern — `run:` steps use `"${MATRIX_PATH}"` env var instead of direct `${{ }}` interpolation
- Adds per-approach timing instrumentation for benchmarking
- Rewrites README with comparison table (TODOs for actual duration data), security note, and alternatives discussion (dorny/paths-filter)

## Test plan

- [x] All 5 `createMatrix_*` jobs pass and produce `["example_1/","example_2/"]`
- [x] All 5 `use_matrix_*` jobs fan out into 2 sub-jobs each
- [x] Each consumer sub-job echoes the correct path and cats the correct file
- [x] Timing output visible in generation step logs
- [x] Rendered README looks correct on the PR
